### PR TITLE
add resolve option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Default: `undefined`
 
 npm registry to install the package from. By default it uses the default npm registry.
 
+#### resolve
+
+Type: `string`<br>
+Default: `undefined`
+
+Extra folders to resolve local node_modules from.
+
 ## Contributing
 
 1. Fork it!

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm registry to install the package from. By default it uses the default npm reg
 
 #### resolve
 
-Type: `string`<br>
+Type: `string` `string[]`<br>
 Default: `undefined`
 
 Extra folders to resolve local node_modules from.

--- a/cli.js
+++ b/cli.js
@@ -124,7 +124,7 @@ cli
   .option('--port <port>', 'Port to start analyze on. Defaults to 8888')
   .option('--registry <registry>', 'npm registry URL to install from')
   .option(
-    '--resolve [resolve]',
+    '--resolve <directory>',
     'Extra folders to resolve local node_modules from'
   )
   .example(`  package-size react,react-dom`)

--- a/cli.js
+++ b/cli.js
@@ -123,6 +123,10 @@ cli
   .option('--analyze', 'Analyze bundled files')
   .option('--port <port>', 'Port to start analyze on. Defaults to 8888')
   .option('--registry <registry>', 'npm registry URL to install from')
+  .option(
+    '--resolve [resolve]',
+    'Extra folders to resolve local node_modules from'
+  )
   .example(`  package-size react,react-dom`)
   .example(`  package-size styled-jsx/style --externals react`)
   .example(`  package-size ./dist/my-bundle.js`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,16 +95,12 @@ module.exports = co.wrap(function*(name, opts = {}) {
   if (yarnGlobal.inDirectory(__dirname)) {
     config.resolve.modules.push(path.join(yarnGlobal.getDirectory()))
   }
+  
+  if (opts.resolve) {
+    config.resolve.modules = config.resolve.modules.concat(opts.resolve)
+  }
 
   if (isCwd) {
-    if (opts.resolve) {
-      if (Array.isArray(opts.resolve)) {
-        opts.resolve.map(resolve => config.resolve.modules.unshift(resolve))
-      } else {
-        config.resolve.modules.unshift(opts.resolve)
-      }
-    }
-
     config.resolve.modules.unshift(path.join(process.cwd(), 'node_modules'))
     const pkg = yield readPkg(process.cwd())
     config.externals = config.externals.concat(

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,14 @@ module.exports = co.wrap(function*(name, opts = {}) {
   }
 
   if (isCwd) {
+    if (opts.resolve) {
+      if (Array.isArray(opts.resolve)) {
+        opts.resolve.map(resolve => config.resolve.modules.unshift(resolve))
+      } else {
+        config.resolve.modules.unshift(opts.resolve)
+      }
+    }
+
     config.resolve.modules.unshift(path.join(process.cwd(), 'node_modules'))
     const pkg = yield readPkg(process.cwd())
     config.externals = config.externals.concat(


### PR DESCRIPTION
When using `package-size` in a monorepo with local packages a user might need to specify extra directories to resolve node modules from. 